### PR TITLE
feat: add option to keep plus symbol

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,13 +77,25 @@ function customDecodeURIComponent(input) {
 	return input;
 }
 
-module.exports = function (encodedURI) {
+module.exports = function (encodedURI, options) {
+	var defaultOptions = {
+		replacePlusForSpace: true
+	};
+
+	if (options) {
+		options = Object.assign(defaultOptions, options);
+	} else {
+		options = defaultOptions;
+	}
+
 	if (typeof encodedURI !== 'string') {
 		throw new TypeError('Expected `encodedURI` to be of type `string`, got `' + typeof encodedURI + '`');
 	}
 
 	try {
-		encodedURI = encodedURI.replace(/\+/g, ' ');
+		if (options.replacePlusForSpace) {
+			encodedURI = encodedURI.replace(/\+/g, ' ');
+		}
 
 		// Try the built in decoder first
 		return decodeURIComponent(encodedURI);

--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,7 @@ decodeUriComponent('%C2%B5');
 
 ## API
 
-### decodeUriComponent(encodedURI)
+### decodeUriComponent(encodedURI, options)
 
 #### encodedURI
 
@@ -64,6 +64,18 @@ Type: `string`
 
 An encoded component of a Uniform Resource Identifier.
 
+#### options
+
+Type: `object`
+
+An object with options, posible values:
+
+##### replacePlusForSpace
+
+Type: `boolean`
+default: `true`
+
+Wether or not to replace `+` for ` `.
 
 ## License
 

--- a/test.js
+++ b/test.js
@@ -35,8 +35,13 @@ const tests = {
 	'%%C2%B5%': '%µ%'
 };
 
-function macro(t, input, expected) {
-	t.is(m(input), expected);
+const plusSymbolTests = {
+	'a+b+c+d': 'a+b+c+d',
+	'%61+%4d%4D': 'a+MM'
+};
+
+function macro(t, options, input, expected) {
+	t.is(m(input, options), expected);
 }
 
 macro.title = (providedTitle, input, expected) => `${input} → ${expected}`;
@@ -46,5 +51,9 @@ test('type error', t => {
 });
 
 for (const input of Object.keys(tests)) {
-	test(macro, input, tests[input]);
+	test(macro, undefined, input, tests[input]);
+}
+
+for (const input of Object.keys(plusSymbolTests)) {
+	test(macro, {replacePlusForSpace: false}, input, plusSymbolTests[input]);
 }


### PR DESCRIPTION
Hey! thanks for the open source package. I need to use it along the `query-string` package with an option to keep plus symbol.

I've added docs and tests.