### PR TITLE
Martinjackson patch for vulnerable to denial of service

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,9 +30,14 @@ function decode(input) {
 	} catch (err) {
 		var tokens = input.match(singleMatcher);
 
-		for (var i = 1; i < tokens.length; i++) {
-			input = decodeComponents(tokens, i).join('');
+		for (var i = 1; tokens && i < tokens.length; i++) {
 
+			// sometimes decoded is a string and not array, but why?  
+			// this just address the "vulnerable to Denial of Service (DoS) - https://github.com/advisories/GHSA-w573-4hg7-7wgq"
+			
+      			const decoded = decodeComponents(tokens, i)      			
+			input = Array.isArray(decoded) ? decoded.join('') : decoded
+			
 			tokens = input.match(singleMatcher);
 		}
 

--- a/test2.js
+++ b/test2.js
@@ -1,0 +1,8 @@
+
+// const decodeUriComponent = require('decode-uri-component');
+const decodeUriComponent = require('./index.js');
+
+var x = decodeUriComponent('%ea%ba%5a%ba');
+
+console.log(x);
+


### PR DESCRIPTION
I think I have addressed the DoS when decodeComponents(tokens, i) returns a string instead of an Array where decodeComponents(tokens, i).join('') will blow up.  
I did not dig deeper to find out why it returns a string instead of array.